### PR TITLE
Add fetchMode modline

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,25 @@ $r->getById(3);
 ```
 
 Or we want to define the PDO fetch mode. (http://php.net/manual/en/pdo.constants.php#pdo.constants.fetch-lazy)
+
+The available fetchmodes are: `assoc`, `class`, `column`, `keypair`, `named`
 ```sql
--- name: getKeyed fetchMode: KEY_PAIR
+-- name: getKeyed fetchMode: keypair
 select id, something from test_table
+-- name: getColumn fetchMode: column
+select id from test_table
+-- name: getObjectById oneOrMany: one fetchMod: class(MyObject)
+select * from test_table where id = ?
 ```
 ```php
 // returns an array with the id column as key and something column as value
 $r->getKeyed();
+// returns a one-dimensional array of ids
+$r->getColumn();
+// returns one row, which is an instance of MyObject with id and something set
+class MyObject {
+}
+$r->getObjectById(3);
 ```
 
 Maybe we want to return a modified version of the row. By specifying a
@@ -95,19 +107,6 @@ class MyObject {
 }
 // return one row, with keys id and ohwow
 $r->getMappedById(3);
-```
-
-Sometimes an object is want you want, rowClass got your back:
-
-```sql
--- name: getObjectById oneOrMany: one rowClass: MyObject
-select * from test_table where id = ?
-```
-```php
-class MyObject {
-}
-// return one row, which is an instance of MyObject with id and something set
-$r->getObjectById(3);
 ```
 
 Maybe we have a class with a `toRow` method we'd like to call on insert

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ select * from test_table where id = ?;
 $r->getById(3);
 ```
 
+Or we want to define the PDO fetch mode. (http://php.net/manual/en/pdo.constants.php#pdo.constants.fetch-lazy)
+```sql
+-- name: getKeyed fetchMode: KEY_PAIR
+select id, something from test_table
+```
+```php
+// returns an array with the id column as key and something column as value
+$r->getKeyed();
+```
+
 Maybe we want to return a modified version of the row. By specifying a
 rowFunc, we can have a function called, on every row returned:
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The available fetchmodes are: `assoc`, `class`, `column`, `keypair`, `named`
 select id, something from test_table
 -- name: getColumn fetchMode: column
 select id from test_table
--- name: getObjectById oneOrMany: one fetchMod: class(MyObject)
+-- name: getObjectById oneOrMany: one fetchMode: class(MyObject)
 select * from test_table where id = ?
 ```
 ```php

--- a/src/Nulpunkt/Yesql/Exception/UnknownFetchMode.php
+++ b/src/Nulpunkt/Yesql/Exception/UnknownFetchMode.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Nulpunkt\Yesql\Exception;
+
+class UnknownFetchMode extends \RuntimeException
+{
+}

--- a/src/Nulpunkt/Yesql/FetchMode/Assoc.php
+++ b/src/Nulpunkt/Yesql/FetchMode/Assoc.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+use PDOStatement;
+
+class Assoc extends BaseFetchMode
+{
+    public function setMode(PDOStatement $stmt)
+    {
+        $stmt->setFetchMode(\PDO::FETCH_ASSOC);
+    }
+}

--- a/src/Nulpunkt/Yesql/FetchMode/BaseFetchMode.php
+++ b/src/Nulpunkt/Yesql/FetchMode/BaseFetchMode.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+use PDOStatement;
+
+abstract class BaseFetchMode implements FetchMode
+{
+    public function setArgument($argument){}
+
+    abstract public function setMode(PDOStatement $stmt);
+}

--- a/src/Nulpunkt/Yesql/FetchMode/Column.php
+++ b/src/Nulpunkt/Yesql/FetchMode/Column.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+use PDOStatement;
+
+class Column extends BaseFetchMode
+{
+    /** @var int */
+    private $column;
+
+    public function setArgument($argument)
+    {
+        $this->column = $argument ?: 0;
+    }
+
+    public function setMode(PDOStatement $stmt)
+    {
+        $stmt->setFetchMode(\PDO::FETCH_COLUMN, $this->column);
+    }
+}

--- a/src/Nulpunkt/Yesql/FetchMode/Factory.php
+++ b/src/Nulpunkt/Yesql/FetchMode/Factory.php
@@ -47,11 +47,11 @@ class Factory implements FetchModeFactory
             $argument = isset($m[3]) ? $m[3] : null;
         }
 
-        return [$fetchMode, $argument];
+        return [strtolower($fetchMode), $argument];
     }
 
     protected function getFetchModeRegex()
     {
-        return '/fetchMode:\s*(assoc|column|keypair|named|class)(\((.*?)\))?/';
+        return '/fetchMode:\s*(\w+)(\((.*?)\))?/';
     }
 }

--- a/src/Nulpunkt/Yesql/FetchMode/Factory.php
+++ b/src/Nulpunkt/Yesql/FetchMode/Factory.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+use Nulpunkt\Yesql\Exception\UnknownFetchMode;
+
+class Factory implements FetchModeFactory
+{
+    public function createFromModLine($modLine)
+    {
+        list($mode, $argument) = $this->processModLine($modLine);
+
+        $fetchModes = [
+            'assoc' => Assoc::class,
+            'class' => FetchClass::class,
+            'column' => Column::class,
+            'keypair' => KeyPair::class,
+            'named' => Named::class,
+        ];
+
+        if (!isset($fetchModes[$mode])) {
+            throw new UnknownFetchMode(
+                "{$mode} is not a supported fetchMode."
+            );
+        }
+
+        /** @var \Nulpunkt\Yesql\FetchMode\FetchMode $fetchMode */
+        $fetchMode = new $fetchModes[$mode];
+        $fetchMode->setArgument($argument);
+
+        return $fetchMode;
+    }
+
+    protected function processModLine($modLine)
+    {
+        $fetchMode = 'assoc';
+        $argument = null;
+
+        // Backwards compatibility
+        if (preg_match('/rowClass:\s*(\S+)/', $modLine, $m)) {
+            $fetchMode = 'class';
+            $argument = @$m[1];
+        }
+
+        if (preg_match($this->getFetchModeRegex(), $modLine, $m)) {
+            $fetchMode = isset($m[1]) ? $m[1] : 'assoc';
+            $argument = isset($m[3]) ? $m[3] : null;
+        }
+
+        return [$fetchMode, $argument];
+    }
+
+    protected function getFetchModeRegex()
+    {
+        return '/fetchMode:\s*(assoc|column|keypair|named|class)(\((.*?)\))?/';
+    }
+}

--- a/src/Nulpunkt/Yesql/FetchMode/FetchClass.php
+++ b/src/Nulpunkt/Yesql/FetchMode/FetchClass.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+use Nulpunkt\Yesql\Exception\ClassNotFound;
+use PDOStatement;
+
+class FetchClass extends BaseFetchMode
+{
+    /** @var string */
+    private $className;
+
+    public function setArgument($argument)
+    {
+        if (!class_exists($argument)) {
+            throw new ClassNotFound("{$argument} is not a class");
+        }
+        $this->className = $argument;
+    }
+
+    public function setMode(PDOStatement $stmt)
+    {
+        $stmt->setFetchMode(\PDO::FETCH_COLUMN, $this->className);
+    }
+}

--- a/src/Nulpunkt/Yesql/FetchMode/FetchClass.php
+++ b/src/Nulpunkt/Yesql/FetchMode/FetchClass.php
@@ -20,6 +20,6 @@ class FetchClass extends BaseFetchMode
 
     public function setMode(PDOStatement $stmt)
     {
-        $stmt->setFetchMode(\PDO::FETCH_COLUMN, $this->className);
+        $stmt->setFetchMode(\PDO::FETCH_CLASS, $this->className);
     }
 }

--- a/src/Nulpunkt/Yesql/FetchMode/FetchMode.php
+++ b/src/Nulpunkt/Yesql/FetchMode/FetchMode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+use PDOStatement;
+
+interface FetchMode
+{
+    /**
+     * The optional argument from the modline
+     * For example:
+     *   -- name: getFoo fetchMode: class(foobar)
+     *   This modline would have foobar as argument
+     *
+     * @param string $argument
+     * @return void
+     */
+    public function setArgument($argument);
+
+    /**
+     * Applies the fetchMode to the PDOStatement
+     *
+     * @param \PDOStatement $stmt
+     * @return void
+     */
+    public function setMode(PDOStatement $stmt);
+}

--- a/src/Nulpunkt/Yesql/FetchMode/FetchModeFactory.php
+++ b/src/Nulpunkt/Yesql/FetchMode/FetchModeFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+interface FetchModeFactory
+{
+    /**
+     * Creates a FetchMode based on the modline
+     *
+     * @param string $modLine
+     * @return \Nulpunkt\Yesql\FetchMode\FetchMode
+     */
+    public function createFromModLine($modLine);
+}

--- a/src/Nulpunkt/Yesql/FetchMode/KeyPair.php
+++ b/src/Nulpunkt/Yesql/FetchMode/KeyPair.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+use PDOStatement;
+
+class KeyPair extends BaseFetchMode
+{
+    public function setMode(PDOStatement $stmt)
+    {
+        $stmt->setFetchMode(\PDO::FETCH_KEY_PAIR);
+    }
+}

--- a/src/Nulpunkt/Yesql/FetchMode/Named.php
+++ b/src/Nulpunkt/Yesql/FetchMode/Named.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Nulpunkt\Yesql\FetchMode;
+
+use PDOStatement;
+
+class Named extends BaseFetchMode
+{
+    public function setMode(PDOStatement $stmt)
+    {
+        $stmt->setFetchMode(\PDO::FETCH_NAMED);
+    }
+}

--- a/src/Nulpunkt/Yesql/Repository.php
+++ b/src/Nulpunkt/Yesql/Repository.php
@@ -14,7 +14,7 @@ class Repository
         $this->db = $db;
         $this->sqlFile = $sqlFile;
 
-        $this->statements = (new Statement\Factory)->createStatements($this->sqlFile);
+        $this->statements = (new Statement\Factory(new FetchMode\Factory))->createStatements($this->sqlFile);
     }
 
     public function __call($name, $args)

--- a/src/Nulpunkt/Yesql/Statement/Factory.php
+++ b/src/Nulpunkt/Yesql/Statement/Factory.php
@@ -3,9 +3,18 @@
 namespace Nulpunkt\Yesql\Statement;
 
 use Nulpunkt\Yesql\Exception\UnknownStatement;
+use Nulpunkt\Yesql\FetchMode\FetchModeFactory;
 
 class Factory
 {
+    /** @var \Nulpunkt\Yesql\FetchMode\FetchModeFactory */
+    private $fetchModeFactory;
+
+    public function __construct(FetchModeFactory $fetchModeFactory)
+    {
+        $this->fetchModeFactory = $fetchModeFactory;
+    }
+
     public function createStatements($sqlFile)
     {
         $collected = [];
@@ -38,7 +47,8 @@ class Factory
     private function createStatement($collectedSql, $modline)
     {
         if (stripos($collectedSql, 'select') === 0) {
-            return new Select($collectedSql, $modline);
+            $fetchMode = $this->fetchModeFactory->createFromModLine($modline);
+            return new Select($collectedSql, $modline, $fetchMode);
         } elseif (stripos($collectedSql, 'insert') === 0) {
             return new Insert($collectedSql, $modline);
         } elseif (stripos($collectedSql, 'update') === 0 || stripos($collectedSql, 'delete') === 0) {

--- a/src/Nulpunkt/Yesql/Statement/Factory.php
+++ b/src/Nulpunkt/Yesql/Statement/Factory.php
@@ -8,7 +8,7 @@ use Nulpunkt\Yesql\FetchMode\FetchModeFactory;
 class Factory
 {
     /** @var \Nulpunkt\Yesql\FetchMode\FetchModeFactory */
-    private $fetchModeFactory;
+    protected $fetchModeFactory;
 
     public function __construct(FetchModeFactory $fetchModeFactory)
     {

--- a/src/Nulpunkt/Yesql/Statement/Select.php
+++ b/src/Nulpunkt/Yesql/Statement/Select.php
@@ -32,7 +32,7 @@ class Select implements Statement
         if ($this->rowClass) {
             $this->stmt->setFetchMode(\PDO::FETCH_CLASS, $this->rowClass);
         } else {
-            $this->stmt->setFetchMode(\PDO::FETCH_ASSOC);
+            $this->stmt->setFetchMode($this->getFetchMode());
         }
 
         $res = array_map([$this, 'prepareElement'], $this->stmt->fetchAll());
@@ -53,6 +53,22 @@ class Select implements Statement
 
         if ($c && !class_exists($c)) {
             throw new \Nulpunkt\Yesql\Exception\ClassNotFound("{$c} is not a class");
+        }
+
+        return $c;
+    }
+
+    private function getFetchMode()
+    {
+        preg_match('/fetchMode:\s*(\S+)/', $this->modline, $m);
+        $c = isset($m[1]) ? $m[1] : 'ASSOC';
+
+        $fetchMode = "\PDO::FETCH_$c";
+
+        $c = constant($fetchMode);
+
+        if (!$c) {
+            throw new \Nulpunkt\Yesql\Exception\UnknownFetchMode("{$fetchMode} is not a PDO fetch mode");
         }
 
         return $c;

--- a/src/Nulpunkt/Yesql/Statement/Select.php
+++ b/src/Nulpunkt/Yesql/Statement/Select.php
@@ -2,21 +2,23 @@
 
 namespace Nulpunkt\Yesql\Statement;
 
+use Nulpunkt\Yesql\FetchMode\FetchMode;
+
 class Select implements Statement
 {
     private $sql;
     private $modline;
     private $rowFunc;
     private $stmt;
+    /** @var \Nulpunkt\Yesql\FetchMode\FetchMode  */
     private $fetchMode;
 
-    public function __construct($sql, $modline)
+    public function __construct($sql, $modline, FetchMode $fetchMode)
     {
         $this->sql = $sql;
         $this->modline = $modline;
         $this->rowFunc = $this->getRowFunc();
-        $this->rowClass = $this->getRowClass();
-        $this->fetchMode = $this->getFetchMode();
+        $this->fetchMode = $fetchMode;
     }
 
     public function execute($db, $args)
@@ -31,11 +33,7 @@ class Select implements Statement
             $this->stmt->execute();
         }
 
-        if ($this->rowClass) {
-            $this->stmt->setFetchMode(\PDO::FETCH_CLASS, $this->rowClass);
-        } else {
-            $this->stmt->setFetchMode($this->fetchMode);
-        }
+        $this->fetchMode->setMode($this->stmt);
 
         $res = array_map([$this, 'prepareElement'], $this->stmt->fetchAll());
 
@@ -46,34 +44,6 @@ class Select implements Statement
     {
         preg_match("/\boneOrMany:\s*(one|many)/", $this->modline, $m);
         return isset($m[1]) ? $m[1] : "many";
-    }
-
-    private function getRowClass()
-    {
-        preg_match('/rowClass:\s*(\S+)/', $this->modline, $m);
-        $c = @$m[1];
-
-        if ($c && !class_exists($c)) {
-            throw new \Nulpunkt\Yesql\Exception\ClassNotFound("{$c} is not a class");
-        }
-
-        return $c;
-    }
-
-    private function getFetchMode()
-    {
-        preg_match('/fetchMode:\s*(\S+)/', $this->modline, $m);
-        $c = isset($m[1]) ? $m[1] : 'ASSOC';
-
-        $fetchMode = "\PDO::FETCH_$c";
-
-        $c = @constant($fetchMode);
-
-        if (!$c) {
-            throw new \Nulpunkt\Yesql\Exception\UnknownFetchMode("{$fetchMode} is not a PDO fetch mode");
-        }
-
-        return $c;
     }
 
     private function getRowFunc()

--- a/src/Nulpunkt/Yesql/Statement/Select.php
+++ b/src/Nulpunkt/Yesql/Statement/Select.php
@@ -8,6 +8,7 @@ class Select implements Statement
     private $modline;
     private $rowFunc;
     private $stmt;
+    private $fetchMode;
 
     public function __construct($sql, $modline)
     {
@@ -15,6 +16,7 @@ class Select implements Statement
         $this->modline = $modline;
         $this->rowFunc = $this->getRowFunc();
         $this->rowClass = $this->getRowClass();
+        $this->fetchMode = $this->getFetchMode();
     }
 
     public function execute($db, $args)
@@ -32,7 +34,7 @@ class Select implements Statement
         if ($this->rowClass) {
             $this->stmt->setFetchMode(\PDO::FETCH_CLASS, $this->rowClass);
         } else {
-            $this->stmt->setFetchMode($this->getFetchMode());
+            $this->stmt->setFetchMode($this->fetchMode);
         }
 
         $res = array_map([$this, 'prepareElement'], $this->stmt->fetchAll());

--- a/src/Nulpunkt/Yesql/Statement/Select.php
+++ b/src/Nulpunkt/Yesql/Statement/Select.php
@@ -67,7 +67,7 @@ class Select implements Statement
 
         $fetchMode = "\PDO::FETCH_$c";
 
-        $c = constant($fetchMode);
+        $c = @constant($fetchMode);
 
         if (!$c) {
             throw new \Nulpunkt\Yesql\Exception\UnknownFetchMode("{$fetchMode} is not a PDO fetch mode");

--- a/test/Nulpunkt/Yesql/Statement/SelectTest.php
+++ b/test/Nulpunkt/Yesql/Statement/SelectTest.php
@@ -2,6 +2,9 @@
 
 namespace Nulpunkt\Yesql\Statement;
 
+use Nulpunkt\Yesql\FetchMode\Assoc;
+use Nulpunkt\Yesql\FetchMode\Factory;
+
 class SelectTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -9,7 +12,7 @@ class SelectTest extends \PHPUnit_Framework_TestCase
     */
     public function testWeComplainIfRowFuncDoesNotExsist()
     {
-        new Select(null, 'rowFunc: sntaoheu');
+        new Select(null, 'rowFunc: sntaoheu', new Assoc);
     }
 
     /**
@@ -17,6 +20,6 @@ class SelectTest extends \PHPUnit_Framework_TestCase
      */
     public function testWeComplainIfFetchModeIsUnknown()
     {
-        new Select(null, 'fetchMode: sntaoheu');
+        (new Factory)->createFromModLine('fetchMode: sntaoheu');
     }
 }

--- a/test/Nulpunkt/Yesql/Statement/SelectTest.php
+++ b/test/Nulpunkt/Yesql/Statement/SelectTest.php
@@ -11,4 +11,12 @@ class SelectTest extends \PHPUnit_Framework_TestCase
     {
         new Select(null, 'rowFunc: sntaoheu');
     }
+
+    /**
+     * @expectedException \Nulpunkt\Yesql\Exception\UnknownFetchMode
+     */
+    public function testWeComplainIfFetchModeIsUnknown()
+    {
+        new Select(null, 'fetchMode: sntaoheu');
+    }
 }


### PR DESCRIPTION
With this PR you'll be able to change the used PDO fetch mode on your select queries.

There is support for `assoc`, `class`, `column`, `keypair` and `named`.

```sql
-- name: getNormal
select id, something from test_table

-- name: getKeyed fetchMode: keypair
select id, something from test_table
```
```php
// Key using a foreach
$keyed = [];
foreach($r->getNormal() as $row) {
  $keyed[$row['id']] = $row['something'];
}

// Or simply
$keyed = $r->getKeyed();
```

The fetch modes `class` and `column` require arguments ( classname and column number ). You can pass those in parentheses. The `column` fetchmode has a default argument of `0`.

Eg:

```sql
-- name: getObjectById oneOrMany: one fetchMode: class(MyObject)
select * from test_table where id = ?
-- name: getColumn fetchMode: column
select id from test_table
```
```php
// returns one row, which is an instance of MyObject with id and something set
class MyObject {
}
$r->getObjectById(3);
// returns a one-dimensional array of ids
$r->getColumn();
```
