### PR TITLE
Named parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ $r->getAllRows();
 ## Inserting a row
 A database without rows is not of much use, lets insert some data:
 ```sql
--- name: insertRow
-insert into test_table (something) values (?)
+-- name: insertRow(thing)
+insert into test_table (something) values (:thing)
 
 ```
 ```php
@@ -53,13 +53,13 @@ the query associated with it. We'll see how to make mappers further down.
 ## Updating a row
 Maybe we need to fix some exsisting data
 ```sql
--- name: updateRow
-update test_table set something = ? where id = ?
+-- name: updateRow(id, thing)
+update test_table set something = :thing where id = :id
 
 ```
 ```php
 // returns the number of rows touched by the update
-$r->updateRow('fixed thing', 3);
+$r->updateRow(3, 'fixed thing');
 ```
 
 ## Fetching a single row
@@ -67,8 +67,8 @@ yesql-php support different modlines, lets say we know we only need to get one
 row:
 
 ```sql
--- name: getById oneOrMany: one
-select * from test_table where id = ?;
+-- name: getById(id) oneOrMany: one
+select * from test_table where id = :id;
 ```
 ```php
 // Fetches one row with id 3
@@ -80,8 +80,8 @@ Maybe we want to return a modified version of the row. By specifying a
 rowFunc, we can have a function called, on every row returned:
 
 ```sql
--- name: getMappedById oneOrMany: one rowFunc: MyObject::mapRow
-select * from test_table where id = ?
+-- name: getMappedById(id) oneOrMany: one rowFunc: MyObject::mapRow
+select * from test_table where id = :id
 ```
 ```php
 class MyObject {
@@ -97,8 +97,8 @@ $r->getMappedById(3);
 Sometimes an object is want you want, rowClass got your back:
 
 ```sql
--- name: getObjectById oneOrMany: one rowClass: MyObject
-select * from test_table where id = ?
+-- name: getObjectById(id) oneOrMany: one rowClass: MyObject
+select * from test_table where id = :id
 ```
 ```php
 class MyObject {
@@ -107,9 +107,9 @@ class MyObject {
 $r->getObjectById(3);
 ```
 
-## Mapping data on the way in / Using named parameters on insert / update
+## Mapping data on the way in
 We may need to map our domain objects to be able to insert them into the
-database. This allows us to name our parameters as well:
+database.
 ```sql
 -- name: insertObject inFunc: MyObject::toRow
 insert into test_table (id, something) values (:id, :something)

--- a/src/Nulpunkt/Yesql/Statement/Collector.php
+++ b/src/Nulpunkt/Yesql/Statement/Collector.php
@@ -4,19 +4,24 @@ namespace Nulpunkt\Yesql\Statement;
 
 class Collector
 {
-    private $methodName;
+    private $method;
     private $modline;
     private $sql;
 
-    public function __construct($methodName, $modline)
+    public function __construct($method, $modline)
     {
-        $this->methodName = $methodName;
+        $this->method = $method;
         $this->modline = $modline;
     }
 
     public function getMethodName()
     {
-        return $this->methodName;
+        return $this->method->getName();
+    }
+
+    public function getArgNames()
+    {
+        return $this->method->getArgNames();
     }
 
     public function getSql()

--- a/src/Nulpunkt/Yesql/Statement/MapInput.php
+++ b/src/Nulpunkt/Yesql/Statement/MapInput.php
@@ -7,10 +7,11 @@ class MapInput implements Statement
     private $statement;
     private $modline;
 
-    public function __construct($statement, $modline)
+    public function __construct($statement, $modline, $argNames)
     {
         $this->statement = $statement;
         $this->modline = $modline;
+        $this->argNames = $argNames;
         $this->inFunc = $this->getInFunc();
     }
 
@@ -18,6 +19,10 @@ class MapInput implements Statement
     {
         if ($this->inFunc) {
             $args = call_user_func_array($this->inFunc, $args);
+        }
+        if (count($this->argNames) > 0) {
+            $args = array_combine($this->argNames, $args);
+
         }
         return $this->statement->execute($db, $args);
     }

--- a/src/Nulpunkt/Yesql/Statement/Method.php
+++ b/src/Nulpunkt/Yesql/Statement/Method.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Nulpunkt\Yesql\Statement;
+
+class Method
+{
+    private $name;
+    private $argNames;
+
+    public function __construct($name, $argNames)
+    {
+        $this->name = $name;
+        $this->argNames = array_filter(array_map('trim', explode(',', $argNames)));
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getArgNames()
+    {
+        return $this->argNames;
+    }
+}

--- a/src/Nulpunkt/Yesql/Statement/Select.php
+++ b/src/Nulpunkt/Yesql/Statement/Select.php
@@ -23,11 +23,7 @@ class Select implements Statement
             $this->stmt = $db->prepare($this->sql);
         }
 
-        if (isset($args)) {
-            $this->stmt->execute($args);
-        } else {
-            $this->stmt->execute();
-        }
+        $this->stmt->execute($args);
 
         if ($this->rowClass) {
             $this->stmt->setFetchMode(\PDO::FETCH_CLASS, $this->rowClass);

--- a/src/Nulpunkt/Yesql/Statement/Update.php
+++ b/src/Nulpunkt/Yesql/Statement/Update.php
@@ -18,11 +18,7 @@ class Update implements Statement
             $this->stmt = $db->prepare($this->sql);
         }
 
-        if (isset($args)) {
-            $this->stmt->execute($args);
-        } else {
-            $this->stmt->execute();
-        }
+        $this->stmt->execute($args);
 
         return $this->stmt->rowCount();
     }

--- a/test/Nulpunkt/Yesql/RepositoryTest.php
+++ b/test/Nulpunkt/Yesql/RepositoryTest.php
@@ -9,6 +9,11 @@ class RepositoryTest extends \TestHelper\TestCase
         $this->assertEquals(['id' => 1, 'something' => 'a thing'], $this->repo->getById(1));
     }
 
+    public function testWeCanGetOneRowWithNamedParam()
+    {
+        $this->assertEquals(['id' => 1, 'something' => 'a thing'], $this->repo->getByIdNamed(1));
+    }
+
     public function testWeCanGetARowThatDoesNotExsist()
     {
         $this->assertNull($this->repo->getById(11));
@@ -68,6 +73,23 @@ class RepositoryTest extends \TestHelper\TestCase
     public function testWeCanUpdate()
     {
         $rowsAffected = $this->repo->updateRow('other thing updated', 2);
+
+        $this->assertSame(1, $rowsAffected);
+
+        $dataSet = $this->createQueryDataset(
+            ['t' => "SELECT * FROM test_table where id = 2"]
+        );
+
+        $expectedData = $this->createArrayDataSet(
+            ['t' => [['id' => 2, 'something' => 'other thing updated']]]
+        );
+
+        $this->assertDataSetsEqual($expectedData, $dataSet);
+    }
+
+    public function testWeCanUpdateWithNamedParams()
+    {
+        $rowsAffected = $this->repo->updateRowNamed(2, 'other thing updated');
 
         $this->assertSame(1, $rowsAffected);
 

--- a/test/Nulpunkt/Yesql/Statement/MapInputTest.php
+++ b/test/Nulpunkt/Yesql/Statement/MapInputTest.php
@@ -10,8 +10,18 @@ class MapInputTest extends \PHPUnit_Framework_TestCase
         $s->expects($this->once())->method('execute')
             ->with('db', ['id'=> 3]);
 
-        $m = new MapInput($s, '');
+        $m = new MapInput($s, '', []);
         $m->execute('db', ['id' => 3]);
+    }
+
+    public function testWeCanExecuteAStatementWithNamedParams()
+    {
+        $s = $this->getMock('Nulpunkt\Yesql\Statement\Statement');
+        $s->expects($this->once())->method('execute')
+            ->with('db', ['id'=> 3]);
+
+        $m = new MapInput($s, '', ['id']);
+        $m->execute('db', [3]);
     }
 
     public function testWeCanExecuteAStatementWithInFunc()
@@ -24,7 +34,7 @@ class MapInputTest extends \PHPUnit_Framework_TestCase
         $s->expects($this->once())->method('execute')
             ->with('db', ['id'=> 3, 'something' => 'from object']);
 
-        $m = new MapInput($s, $modline);
+        $m = new MapInput($s, $modline, []);
         $m->execute('db', [$o]);
     }
 
@@ -34,6 +44,6 @@ class MapInputTest extends \PHPUnit_Framework_TestCase
     public function testWeComplainIfInFuncIsNotCallable()
     {
         $modline = 'inFunc: nope.exe';
-        new MapInput(null, $modline);
+        new MapInput(null, $modline, []);
     }
 }

--- a/test/Nulpunkt/Yesql/test.sql
+++ b/test/Nulpunkt/Yesql/test.sql
@@ -2,6 +2,9 @@
 -- This will make getById a method which fetch a test row from the database
 select * from test_table where id = ?
 
+-- name: getByIdNamed(id) oneOrMany: one
+select * from test_table where id = :id
+
 -- name: getObjectByIdManually oneOrMany: one rowFunc: TestHelper\TestObject::fromRow
 select * from test_table where id = ?
 
@@ -23,6 +26,10 @@ insert into test_table (id, something) values (:id, :something)
 -- name: updateRow
 update test_table set something = ?
 where id = ?
+
+-- name: updateRowNamed(id, something)
+update test_table set something = :something
+where id = :id
 
 -- name: updateObject inFunc: TestHelper\TestObject::toRow
 update test_table set something = :something

--- a/test/phpunit.bootstrap.php
+++ b/test/phpunit.bootstrap.php
@@ -1,5 +1,5 @@
 <?php
-error_reporting(E_ALL | E_STRICT);
+error_reporting(-1);
 
 ini_set("memory_limit", "1024M"); // nothing to see here
 


### PR DESCRIPTION
￼Added support of naming parameters in queries directly. Before this, you had to create an inFunc which did the mapping. Rightfully, some have argued that it was probably not the best way to do
it. So now names can be specified directly in the name of the query.