### PR TITLE
PHP 8.3.2 : fixed deprected warnings

### DIFF
--- a/src/Nulpunkt/Yesql/Statement/MapInput.php
+++ b/src/Nulpunkt/Yesql/Statement/MapInput.php
@@ -6,6 +6,8 @@ class MapInput implements Statement
 {
     private $statement;
     private $modline;
+    private $argNames;
+    private $inFunc;
 
     public function __construct($statement, $modline, $argNames)
     {

--- a/src/Nulpunkt/Yesql/Statement/Select.php
+++ b/src/Nulpunkt/Yesql/Statement/Select.php
@@ -7,6 +7,7 @@ class Select implements Statement
     private $sql;
     private $modline;
     private $rowFunc;
+    private $rowClass;
     private $stmt;
 
     public function __construct($sql, $modline)


### PR DESCRIPTION
Prevent info level messages about deprecated creation of dynamic property. like this :

```bash
[PHP-CGI    ] [16-Feb-2024 12:49:23 UTC] [info] Deprecated: Creation of dynamic property Nulpunkt\Yesql\Statement\Select::$rowClass is deprecated
[PHP-CGI    ] [16-Feb-2024 12:49:23 UTC] [info] Deprecated: Creation of dynamic property Nulpunkt\Yesql\Statement\MapInput::$argNames is deprecated
[PHP-CGI    ] [16-Feb-2024 12:49:23 UTC] [info] Deprecated: Creation of dynamic property Nulpunkt\Yesql\Statement\MapInput::$inFunc is deprecated
```